### PR TITLE
Update Tone.js version

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,7 +193,7 @@ limitations under the License.
    }
   </script>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/tone/13.8.25/Tone.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/tone/14.7.58/Tone.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@magenta/music@^1.0.0/es6/core.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/1.3.8/FileSaver.min.js" defer></script>
   <script src="script.js"></script>


### PR DESCRIPTION
Tone.js had a breaking change, magenta.js got updated for it, but the demos didn't.